### PR TITLE
Feature/standardisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,7 @@ run_emdat_normal:
 run_idmc_normal:
 	@echo "Running the application.."
 	@poetry run python -m src.idmc.data_normalisation_idmc
+
+run_cerf_normal:
+	@echo "Running the application.."
+	@poetry run python -m src.cerf.data_normalisation_cerf

--- a/src/cerf/data_normalisation_cerf.py
+++ b/src/cerf/data_normalisation_cerf.py
@@ -20,5 +20,12 @@ with open(SCHEMA_PATH_CERF, "r") as schema_cerf:
 
 cerf_df_raw = pd.read_csv(CERF_INPUT_CSV)
 
-print("Preview of raw data:")
-print(cerf_df_raw.head())
+# print("Preview of raw data:")
+# print(cerf_df_raw.head())
+
+cleaned1_df = map_and_drop_columns(cerf_df_raw, CERF_MAPPING)
+# print("Preview of cleaned data:")
+# print(cleaned1_df.head())
+cleaned2_df = change_data_type(cleaned1_df, cerf_schema)
+os.makedirs("./data_mid/cerf/cleaned_inspection", exist_ok=True)
+cleaned2_df.to_csv("./data_mid/cerf/cleaned_inspection/cleaned_cerf.csv", index=False)


### PR DESCRIPTION
This pull request introduces a new data normalization process for CERF data and updates the `Makefile` to include this new process. The most important changes are:

### Addition of CERF Data Normalization:

* [`src/cerf/data_normalisation_cerf.py`](diffhunk://#diff-25062186718c3f4d18b90ad66e22286378bcccff1047a4466f3fb9729ff5736eR1-R31): Added a new script for CERF data normalization, which includes importing necessary libraries, loading the CERF schema, reading the raw CERF data, mapping and dropping columns, changing data types, and saving the cleaned data to a CSV file.

### Updates to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R108-R111): Added a new target `run_cerf_normal` to run the new CERF data normalization script.